### PR TITLE
Debug code location on GHA runner

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -32,4 +32,4 @@ jobs:
       uses: khaeru/coverage-gh@debug-code-loc
       with:
         token: ${{ github.token }}
-        threshold: 41
+        threshold: 38

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -25,10 +25,11 @@ jobs:
         python -m pip install --upgrade pip pytest-cov \
           click Jinja2 requests
 
-    - name: Run pytest to generate a coverage file; copy; then run all tests
+    - name: Run pytest to generate a coverage file
       run: pytest --color=yes . -k nothing --cov .
 
     - name: Invoke the CLI to annotate the PR
       uses: khaeru/coverage-gh@debug-code-loc
       with:
         token: ${{ github.token }}
+        threshold: 41

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -29,4 +29,4 @@ jobs:
       run: pytest --color=yes . -k nothing --cov .
 
     - name: Invoke the CLI to annotate the PR
-      uses: khaeru/coverage-gh@main
+      uses: khaeru/coverage-gh@debug-code-loc

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -30,3 +30,5 @@ jobs:
 
     - name: Invoke the CLI to annotate the PR
       uses: khaeru/coverage-gh@debug-code-loc
+      with:
+        token: ${{ github.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         pytest --color=yes . -k test_nothing --cov coverage_gh
         cp .coverage coverage_gh/tests/example.coverage
-        pytest --color=yes . --cov coverage_gh
+        pytest --color=yes --verbose . --cov coverage_gh
 
     - name: Invoke the CLI to annotate the PR (dry-run)
-      run: python -m coverage_gh --verbose --dry-run .coverage 100
+      run: python -m coverage_gh --verbose --dry-run .coverage 100 ${{ github.token}}

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# coverage-gh
+.coverage-gh.tmp

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,40 @@
 Integrate Python coverage & GitHub Actions
 ******************************************
 
-🚧 This code is a work in progress, not ready for use.
+This repo provides a minimal Python package and GitHub Action for reporting the outcomes of Python `coverage <https://coverage.readthedocs.io>`_ as a check and annotations on a GitHub pull request.
 
-This repo provides a minimal Python package and GitHub Actions for reporting the outcomes of Python `coverage <https://coverage.readthedocs.io>`_ as a check and annotations on a GitHub pull request.
-Most users—especially those with public repositories—will want to use services like Codecov, Coveralls, etc., which are much more fully-featured.
-These services also provide paid options for private repositories with professional support, which you should consider paying for if your organization can afford to.
-If not, then ``coverage-gh`` fills the niche as "poor man's" option for private repos".
+Most users—especially those with public repositories—will want to use services like `Codecov <https://codecov.io>`_, `Coveralls <https://coveralls.io/>`_. These services provide free options for public repos with many more features, and paid options for private repos with professional support.
+You should consider paying for these if your organization can afford it!
+If not, then ``coverage-gh`` fills the niche as "poor man's" option for private repos.
+
+Usage
+=====
+The action assumes your workflow invokes ``coverage`` (e.g. using `pytest-cov <>`_) to generate a date file, named .coverage by default.
+This is the only file needed by the action, i.e., you do not need to give arguments like ``pytest … --cov-report=xml`` unless otherwise needed.
+
+```
+- uses: khaeru/codecov-gh@0.2
+  with:
+    # Token used to report checks. Required.
+    token: ${{ github.token }}
+
+    # Location of the coverage data file. Optional.
+    #
+    # Default: .coverage, in the GitHub Actions workspace directory.
+    data-file: .coverage
+
+    # Percent coverage required for the check to pass. Optional.
+    #
+    # This is a floating-point number between 0 and 100.
+    #
+    # Default: 100.0
+    threshold: 100.
+```
+
+License & credits
+=================
+
+Copyright © 2022 Paul Natsuo Kishimoto <mail@paul.kishimoto.name>.
+Licensed under the GNU General Public License, version 3.0 or later.
 
 Thanks to `amitds1997/pytest-annotate-pr <https://github.com/amitds1997/pytest-annotate-pr>`_ for demo code for interacting with GitHub's API, heavily adapted here.
-
-Copyright © 2022 Paul Natsuo Kishimoto <mail@paul.kishimoto.name>
-Licensed under the GNU General Public License, version 3.0 or later.

--- a/action.yaml
+++ b/action.yaml
@@ -16,8 +16,8 @@ runs:
   using: docker
   image: Dockerfile
   args:
-    - ${{ inputs.data-file }}
-    - ${{ inputs.threshold }}
+  - ${{ inputs.data-file }}
+  - ${{ inputs.threshold }}
 
 # outputs:
 #   total-pc:

--- a/action.yaml
+++ b/action.yaml
@@ -2,6 +2,8 @@ name: Annotate PR with Python coverage
 description: Annotate PR with Python coverage
 
 inputs:
+  token:
+    description: GitHub API token
   data-file:
     description: Coverage data file
     required: false
@@ -18,6 +20,7 @@ runs:
   args:
   - ${{ inputs.data-file }}
   - ${{ inputs.threshold }}
+  - ${{ inputs.token }}
 
 # outputs:
 #   total-pc:

--- a/coverage_gh/__init__.py
+++ b/coverage_gh/__init__.py
@@ -126,6 +126,7 @@ class GitHubAPIClient:
 
     def __init__(self, **options):
         # Arguments for requests.post()
+        options["token"] = options["token"] or options.pop("token_arg")[0]
         self._request = dict(
             url=f"{options.pop('api_url')}/repos/{options.pop('repo')}/check-runs",
             headers=dict(
@@ -224,9 +225,7 @@ class GitHubAPIClient:
     metavar="GITHUB_REPOSITORY",
     default="user/repo",
 )
-@click.option(
-    "--token", envvar="GITHUB_TOKEN", metavar="GITHUB_TOKEN", default="abc1234567890def"
-)
+@click.option("--token", envvar="GITHUB_TOKEN", metavar="GITHUB_TOKEN", default=None)
 @click.option("--verbose", is_flag=True, help="Display verbose output.")
 @click.option("--dry-run", is_flag=True, help="Only show what would be done.")
 @click.option(
@@ -240,5 +239,6 @@ class GitHubAPIClient:
 )
 @click.argument("data_file")
 @click.argument("threshold", type=float)
+@click.argument("token_arg", nargs=-1)
 def cli(**options):
     GitHubAPIClient(**options).post()

--- a/coverage_gh/tests/test_all.py
+++ b/coverage_gh/tests/test_all.py
@@ -85,6 +85,12 @@ class TestGitHubAPIClient:
         client.post()
 
 
-def test_cli():
+def test_cli(monkeypatch, tmp_path):
+    monkeypatch.setenv("GITHUB_TOKEN", "abc1234567890def")
+
     runner = CliRunner()
-    runner.invoke(cli, ["--dry-run"])
+    result = runner.invoke(
+        cli, ["--dry-run", str(tmp_path.joinpath(".coverage")), "99"]
+    )
+
+    assert 0 == result.exit_code, result.output


### PR DESCRIPTION
The Dockerized action code cannot seem to locate the source files; see e.g. https://github.com/khaeru/coverage-gh/runs/5719196884?check_suite_focus=true

One issue is that the path in the action, e.g. `/home/runner/work/codecov-gh/codecov-gh/` is passed to the action at a different path like `/github/workspace`. The entries in the .coverage file correspond to the former, rather than the latter.