### PR TITLE
Improve dockerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+action.yaml
+LICENSE
+README.rst

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Upgrade pip; install package and dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --editable .
+        pip install --editable .[tests]
 
     - name: Run pytest to generate a coverage file; copy; then run all tests
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
 FROM python:3.10-alpine
 
-LABEL "com.github.actions.name"="Integrate Python coverage & GitHub Actions"
-LABEL "com.github.actions.description"="Add a check and annotations on a GitHub PR based on Python coverage results."
-LABEL "com.github.actions.icon"="shield"
-LABEL "com.github.actions.color"="yellow"
-LABEL "com.github.actions.repository"="https://github.com/khaeru/coverage-dh"
-LABEL "com.github.actions.homepage"="https://github.com/khaeru/coverage-dh"
-LABEL "com.github.actions.maintainer"="Paul Natsuo Kishimoto"
-
 COPY . .
 RUN pip install --no-cache-dir . && \
     rm -r coverage_gh* Dockerfile MANIFEST.in pyproject.toml setup.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ LABEL "com.github.actions.homepage"="https://github.com/khaeru/coverage-dh"
 LABEL "com.github.actions.maintainer"="Paul Natsuo Kishimoto"
 
 COPY . .
-RUN pip install .
+RUN pip install --no-cache-dir . && \
+    rm -r coverage_gh* Dockerfile MANIFEST.in pyproject.toml setup.cfg
 
 ENTRYPOINT ["python", "-m", "coverage_gh"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include coverage_gh/summary.md.template

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ This is the only file needed by the action, i.e., you do not need to give argume
        # This is a floating-point number between 0 and 100.
        #
        # Default: 100.0
-       threshold: 100.
+       threshold: 100.0
 
 License & credits
 =================

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,12 @@ install_requires =
     click
     coverage
     jinja2
-    pytest-cov
     requests
+
+[options.extras_require]
+tests =
+    pytest
+    pytest-cov
 
 [flake8]
 max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ long_description_content_type = text/x-rst
 
 [options]
 packages = coverage_gh
+include_package_data = True
 install_requires =
     click
     coverage


### PR DESCRIPTION
`v1` erroneously ran on the package source files that had been copied into the Docker image, rather than the package as installed into the image. As a result, the code could not find summary.md.template and would fail.

This PR fixes the issue by:
- Explicitly including that file to be installed, via MANIFEST.in. Because Docker does not `COPY` the .git directory by default (i.e. that is an implicit entry in .dockerignore), setuptools-scm cannot identify it as a tracked file and include it among the files to be installed.
- Cleaning up by removing the copied source files; no code can find, import, or run these.